### PR TITLE
Remove unneccessary inspect call in JobError

### DIFF
--- a/lib/task_bunny/job_error.ex
+++ b/lib/task_bunny/job_error.ex
@@ -70,7 +70,10 @@ defmodule TaskBunny.JobError do
       :failed_count,
       :queue
     ])
-    |> Enum.map(fn {k, v} -> {k, inspect(v)} end)
+    |> Enum.map(fn
+      {k, v} when is_binary(v) -> {k, v}
+      {k, v} -> {k, inspect(v)}
+    end)
     |> Map.new()
   end
 


### PR DESCRIPTION
When working with strings, call to inspect adds extra
quotes which just makes working with data trickier.

This only calls inspect for non-binaries such as atoms, maps
and processes.

CHAN-102