### PR TITLE
Adds :noreply return when uncompressing fails

### DIFF
--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -153,7 +153,9 @@ defmodule TaskBunny.Worker do
         decode_body(uncompressed_body, meta, state)
 
       {:error, error} ->
-        Logger.error(log_msg("uncompress_error", state, body: body, meta: meta, error: error))
+        Logger.error(log_msg("uncompress error", state, body: body, meta: meta, error: error))
+
+        {:noreply, update_job_stats(state, :failed)}
     end
   end
 


### PR DESCRIPTION
Previously when an error occurred in uncompress, then the chain didn't get proper
response and logs didn't appear anymore.