### PR TITLE
Allow changing JSON library

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ config :task_bunny, queue: [
 ]
 ```
 
+By default TaskBunny uses Poison to encode/decode JSON. This can be changed using `json_library`:
+```elixir
+config :task_bunny, json_library: Jason
+```
+
 ### 4. Define TaskBunny job
 
 Use `TaskBunny.Job` module in your job module and define `perform/1` that takes a map as an argument.

--- a/lib/task_bunny.ex
+++ b/lib/task_bunny.ex
@@ -3,6 +3,8 @@ defmodule TaskBunny do
   # for more information on OTP Applications
   @moduledoc false
 
+  @json_library Application.get_env(:task_bunny, :json_library, Poison)
+
   use Application
 
   alias TaskBunny.Status
@@ -21,6 +23,8 @@ defmodule TaskBunny do
     opts = [strategy: :one_for_one, name: TaskBunny]
     Supervisor.start_link(children, opts)
   end
+
+  def json_library, do: @json_library
 
   defp register_metrics do
     if Code.ensure_loaded(Wobserver) == {:module, Wobserver} do

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -73,8 +73,9 @@ defmodule TaskBunny.Job do
   @doc """
   Callback to process a job.
 
-  It can take any type of argument as long as it can be serialized with Poison,
-  but we recommend you to use map with string keys for a consistency.
+  It can take any type of argument as long as it can be serialized with the
+  TaskBunny.json_library(), but we recommend you to use map with string keys
+  for a consistency.
 
       def perform(name) do
         IO.puts name <> ", it's not a preferred way"

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -17,7 +17,7 @@ defmodule TaskBunny.Message do
   @spec encode(atom, any) :: {:ok, String.t()}
   def encode(job, payload) do
     data = message_data(job, payload)
-    Poison.encode(data, pretty: true)
+    TaskBunny.json_library().encode(data)
   end
 
   @doc """
@@ -26,7 +26,7 @@ defmodule TaskBunny.Message do
   @spec encode!(atom, any) :: String.t()
   def encode!(job, payload) do
     data = message_data(job, payload)
-    Poison.encode!(data, pretty: true)
+    TaskBunny.json_library().encode!(data)
   end
 
   @spec message_data(atom, any) :: map
@@ -43,7 +43,7 @@ defmodule TaskBunny.Message do
   """
   @spec decode(String.t()) :: {:ok, map} | {:error, any}
   def decode(message) do
-    case Poison.decode(message) do
+    case TaskBunny.json_library().decode(message) do
       {:ok, decoded} ->
         job = decode_job(decoded["job"])
 
@@ -130,9 +130,9 @@ defmodule TaskBunny.Message do
 
   def add_error_log(raw_message, error) do
     raw_message
-    |> Poison.decode!()
+    |> TaskBunny.json_library().decode!()
     |> add_error_log(error)
-    |> Poison.encode!(pretty: true)
+    |> TaskBunny.json_library().encode!()
   end
 
   defp host do
@@ -153,7 +153,7 @@ defmodule TaskBunny.Message do
 
   def failed_count(raw_message) do
     raw_message
-    |> Poison.decode!()
+    |> TaskBunny.json_library().decode!()
     |> failed_count()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule TaskBunny.Mixfile do
       {:excoveralls, "~> 0.5", only: :test},
       {:inch_ex, "~> 0.5", only: [:dev, :test]},
       {:logger_file_backend, "~> 0.0.9", only: :test},
-      {:meck, "~> 0.8.2", only: :test},
+      {:meck, "~> 0.8.13", only: :test},
       {:poolboy, "~> 1.5"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -16,7 +16,7 @@
   "logger_file_backend": {:hex, :logger_file_backend, "0.0.10", "876f9f84ae110781207c54321ffbb62bebe02946fe3c13f0d7c5f5d8ad4fa910", [:mix], [], "hexpm", "0cee4771fb3ab1def4fc4a01b7f5550ae36db0755035b0c426999702c30b6422"},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "d7152ff93f2eac07905f510dfa03397134345ba4673a00fbf7119bab98632940"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "4a36dd2d0d5c5f98d95b3f410d7071cd661d5af310472229dd0e92161f168a44"},
-  "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm", "5eb607516f4a644324f130d2ad8893d4097020e8d6097193d9f7be55ee8d00d6"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm", "d34f013c156db51ad57cc556891b9720e6a1c1df5fe2e15af999c84d6cebeb1a"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm", "7a4c8e1115a2732a67d7624e28cf6c9f30c66711a9e92928e745c255887ba465"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm", "ebb595e19456a72786db6dcd370d320350cb624f0b6203fcc7e23161d49b0ffb"},


### PR DESCRIPTION
Many people prefer Jason over Poison because it can be faster. Phoenix framework did the [same switch](https://github.com/phoenixframework/phoenix/commit/02a204a33dc57bc215bf19581f2256c6d40dffde) over a year ago now.

This commit makes the JSON library customizable. It still defaults to Poison to ensure that we don't break anything for people that are upgrading the library.

It's now possible to use Jason (and even jiffy when using a wrapper).

The only other change is that encode function is no longer using `pretty: true`. This should give a tiny performance boost.