### PR TITLE
Convert DateTime to ISO8601 before JSON encode

### DIFF
--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -34,7 +34,7 @@ defmodule TaskBunny.Message do
     %{
       "job" => encode_job(job),
       "payload" => payload,
-      "created_at" => DateTime.utc_now()
+      "created_at" => DateTime.to_iso8601(DateTime.utc_now())
     }
   end
 


### PR DESCRIPTION
This is similar to 0af4013 but for encode. Jiffy doesn't automatically
convert the dates to iso8601.